### PR TITLE
Adding cygwin audio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Here is the clandestine command you can give to your friends :)
 ![rickroll in xterm](http://i.imgur.com/ZAsQWtP.png)
 ![rickroll in mac](http://i.imgur.com/yDLaZna.png)
 
-This has been tested on arch, debian and mac (so far).
-There is currently no sound in cygwin, but that is to be fixed.
+This has been tested on arch, debian, mac and cygwin (so far).
+To enable sound in cygwin, install the **sox** package.
 
 For the record: It is not actually a good idea to make a habit of:
 "curl $(random_script_from_the_internets) | bash"

--- a/roll.sh
+++ b/roll.sh
@@ -128,8 +128,11 @@ elif hash aplay 2>/dev/null; then
   obtainium $bean/roll.s16 | aplay -q -f S16_LE -r 8000 &
   audpid=$!
 elif hash play 2>/dev/null; then
-  # On cygwin if the play command is available (via "sox" package), stream raw sound.
-  obtainium $bean/roll.s16 | play -q --endian little -r 8000 -c 1 roll.s16 &
+  # On Cygwin, if the play command is available (via the sox package), pre-fetch
+  # compressed audio.
+  echo "downloading audio..."
+  obtainium $bean/roll.gsm.wav >/tmp/roll.gsm.wav
+  play -q /tmp/roll.gsm.wav &
   audpid=$!
 fi
 


### PR DESCRIPTION
Install the "sox" package in cygwin to get the play executable installed. That can play the raw sound file without a problem!
