### PR TITLE
Prefer paplay over aplay on systems with PulseAudio

### DIFF
--- a/roll.sh
+++ b/roll.sh
@@ -61,6 +61,8 @@ if has? afplay; then
   # On Mac OS, if |afplay| available, pre-fetch compressed audio.
   [ -f /tmp/roll.s16 ] || obtainium $audio_raw >/tmp/roll.s16
   afplay /tmp/roll.s16 &
+elif has? paplay; then
+  obtainium $audio_raw | paplay --format=s16le --rate=8000 &
 elif has? aplay; then
   # On Linux, if |aplay| available, stream raw sound.
   obtainium $audio_raw | aplay -Dplug:default -q -f S16_LE -r 8000 &


### PR DESCRIPTION
I did not have aplay on my system and the audio did not work. Added a line to play the audio with paplay (which is PulseAudio's replacement for aplay) and to actually prefer it over aplay since many modern Linux systems have PulseAudio as their sound system.