### PR TITLE
roll.sh: fix playing audio on GNU/Linux (aplay)

### DIFF
--- a/roll.sh
+++ b/roll.sh
@@ -63,7 +63,7 @@ if has? afplay; then
   afplay /tmp/roll.s16 &
 elif has? aplay; then
   # On Linux, if |aplay| available, stream raw sound.
-  obtainium $audio_raw | aplay -Dplug:default -q -f S16_LE -r 8000 &
+  obtainium $audio_raw | aplay -q &
 elif has? play; then
   # On Cygwin, if |play| is available (via sox), pre-fetch compressed audio.
   obtainium $audio_gsm >/tmp/roll.gsm.wav


### PR DESCRIPTION
The argument -Dplug:default was stopping sound working; removing it makes it
work again.

Rather to my surprise, it also worked with the rest of the arguments
removed. This seems odd given that it claims to be downloading a raw audio
file, but removing -q showed that the audio data aplay was being fed is in
fact a WAV file, and downloading the file and checking it confirms this.

Hence, refer to “wav audio” rather than “raw audio”, and remove all
command-line arguments to aplay. Win!