### PR TITLE
Use /usr/bin/env bash instead of /bin/bash shebang

### DIFF
--- a/roll.sh
+++ b/roll.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Rick Astley in your Terminal.
 # By Serene Han and Justine Tunney <3
 version='1.1'


### PR DESCRIPTION
Some people have 2 versions of bash, for example on my macOS machine I installed bash 5.2, but without disabling SIP it's impossible to put it in /bin/bash. `#!/usr/bin/env bash` will look for the `bash` in their `$PATH`.