### PR TITLE
Fix video not playing on systems with no `python` binary

### DIFF
--- a/roll.sh
+++ b/roll.sh
@@ -74,7 +74,7 @@ audpid=$!
 #echo -e "${yell}Fetching video..."
 # Sync FPS to reality as best as possible. Mac's freebsd version of date cannot
 # has nanoseconds so inject python. :/
-python <(cat <<EOF
+python3 <(cat <<EOF
 import sys
 import time
 fps = 25; time_per_frame = 1.0 / fps

--- a/roll.sh
+++ b/roll.sh
@@ -78,9 +78,11 @@ audpid=$!
 # If `python` does not exist, use `python3` instead
 # needed for Debian 11 and Ubuntu 22.04
 if ! which python > /dev/null ; then
-  python=python3
+  python_binary=python3
+else
+  python_binary=python
 fi
-$python <(cat <<EOF
+$python_binary <(cat <<EOF
 import sys
 import time
 fps = 25; time_per_frame = 1.0 / fps

--- a/roll.sh
+++ b/roll.sh
@@ -74,7 +74,13 @@ audpid=$!
 #echo -e "${yell}Fetching video..."
 # Sync FPS to reality as best as possible. Mac's freebsd version of date cannot
 # has nanoseconds so inject python. :/
-python3 <(cat <<EOF
+
+# If `python` does not exist, use `python3` instead
+# needed for Debian 11 and Ubuntu 22.04
+if ! which python > /dev/null ; then
+  python=python3
+fi
+$python <(cat <<EOF
 import sys
 import time
 fps = 25; time_per_frame = 1.0 / fps


### PR DESCRIPTION
Debian 11 and Ubuntu 22.04 use `python3` as their Python 3 binary. `python` is reserved for Python 2, and is not installed by default.

This commit checks if the `python` binary exists on the system, and if not, uses `python3` instead.

Fixes #40 